### PR TITLE
Edit page "3-quickstart.md"

### DIFF
--- a/src/3-quickstart.md
+++ b/src/3-quickstart.md
@@ -132,6 +132,8 @@ impl<S: Spec> Module for ValueSetter<S> {
 // ... existing code ...
 ```
 
+> Note: The `genesis` method gets called only once when the rollup starts. If you have previously run the rollup, then you must clear the database and start the rollup from scratch to ensure that the `gensis` method gets called and `admin` gets set. You can use the `make clean-db` to achieve this.
+
 ### d) Add the Admin Check in `call`
 
 The final piece. We'll modify the `call` method to read the `admin` address from state and compare it to the transaction sender. If they don't match, the transaction fails.

--- a/src/3-quickstart.md
+++ b/src/3-quickstart.md
@@ -132,7 +132,7 @@ impl<S: Spec> Module for ValueSetter<S> {
 // ... existing code ...
 ```
 
-> Note: The `genesis` method gets called only once when the rollup starts. If you have previously run the rollup, then you must clear the database and start the rollup from scratch to ensure that the `gensis` method gets called and `admin` gets set. You can use the `make clean-db` to achieve this.
+> Note: The `genesis` method gets called only once when the rollup starts. If you have previously run the rollup, then you must clear the database and start the rollup from scratch to ensure that the `gensis` method gets called and `admin` gets set. You can use the `make clean-db` command to achieve this.
 
 ### d) Add the Admin Check in `call`
 


### PR DESCRIPTION
Adds a small note related to restarting the rollup from scratch by clearing the db state and forcing regensis.